### PR TITLE
Change relative fonts URL to absolute

### DIFF
--- a/src/icon.css
+++ b/src/icon.css
@@ -1,7 +1,7 @@
 @font-face {
     font-family: 'element-icons';
-    src: url('fonts/element-icons.woff?t=1472440741') format('woff'), /* chrome, firefox */
-      url('fonts/element-icons.ttf?t=1472440741') format('truetype'); /* chrome, firefox, opera, Safari, Android, iOS 4.2+*/
+    src: url('/fonts/element-icons.woff?t=1472440741') format('woff'), /* chrome, firefox */
+      url('/fonts/element-icons.ttf?t=1472440741') format('truetype'); /* chrome, firefox, opera, Safari, Android, iOS 4.2+*/
     font-weight: normal;
     font-style: normal;
 }


### PR DESCRIPTION
The current font URL has unexpected results.

Example: If browser is in URL http://app.com/users/create, fonts will be loaded from http://app.com/users/create/fonts...., which is likely to return a 404.

This PR proposes adding a slash to the beginning of each font URL to ensure always the same behavior.

Example:
http://app.com/users/create -> http://app.com/fonts....
http://app.com/ -> http://app.com/fonts....